### PR TITLE
Replace DefaultDict in Adjacent with Dict

### DIFF
--- a/docs/src/data_structures/adjacent.md
+++ b/docs/src/data_structures/adjacent.md
@@ -30,5 +30,4 @@ add_triangle!(::Ts, ::V, ::V, ::V) where {I,E,V<:Integer,Ts<:Adjacent{I,E}}
 add_triangle!(::Adjacent, ::Any)
 delete_triangle!(::Ts, ::V, ::V, ::V) where {I,E,V<:Integer,Ts<:Adjacent{I,E}}
 delete_triangle!(::Adjacent, ::Any)
-clear_empty_keys!(::Adjacent)
 ```

--- a/src/data_structures/adjacent.jl
+++ b/src/data_structures/adjacent.jl
@@ -50,7 +50,6 @@ default value is `Val(false)`, meaning this isn't checked.
 - `add_triangle!(adj, T...)`
 - `delete_triangle!(adj, i, j, k)` or `delete_triangle!(adj, T)`
 - `delete_triangle!(adj, T...)`
-- `clear_empty_keys!(adj)`
 
 ## Iteration 
 You can also iterate over `Adjacent` maps the same way as you would 
@@ -239,18 +238,5 @@ end
 Base.iterate(adj::Adjacent, state...) = Base.iterate(get_adjacent(adj), state...)
 Base.length(adj::Adjacent) = Base.length(get_adjacent(adj))
 Base.eltype(::Type{Adjacent{I,E}}) where {I,E} = Pair{E,I}
-
-"""
-    clear_empty_keys!(adj::Adjacent) 
-
-Given an [`Adjacent`](@ref) map `adj`, removes any edges that 
-map to $DefaultAdjacentValue`.
-"""
-function clear_empty_keys!(adj::Adjacent)
-    for (uv, w) in adj
-        !edge_exists(w) && delete_adjacent!(adj, uv)
-    end
-    return nothing
-end
 
 Base.sizehint!(adj::Adjacent, n) = Base.sizehint!(get_adjacent(adj), n)

--- a/src/data_structures/adjacent.jl
+++ b/src/data_structures/adjacent.jl
@@ -10,10 +10,10 @@ See the docs for a description of how boundary edges are handled.
 See also [`Adjacent2Vertex`](@ref).
 
 # Fields 
-- `adjacent::DefaultDict{E,I,I}`
+- `adjacent::Dict{E,I}`
 
 The `Dict` used for storing the edges (the keys) and the associated vertices 
-(the values). If `(u, v)` is not a valid edge, then `w = adjacent[(u, v)]`
+(the values). If `(u, v)` is not a valid edge, then `w = get_adjacent(adjacent, u, v)`
 returns `$DefaultAdjacentValue` (this value is defined in `DefaultAdjacentValue`).
 Otherwise, `(u, v, w)` is a positively oriented triangle.
 
@@ -23,9 +23,9 @@ The adjacent map can be constructed in two ways:
 - `Adjacent{I, E}() where {I, E}`
 
 Creates an empty map.
-- `Adjacent(adj::DefaultDict{E,I,I}) where {E,I,I}`
+- `Adjacent(adj::Dict{E,I,I}) where {E,I,I}`
 
-Creates an adjacent map from an existing `DefaultDict`.
+Creates an adjacent map from an existing `Dict`.
 
 # Extended help 
 You should not work with the `adjacent` field directly. We provide the following 
@@ -70,13 +70,13 @@ end
     boundary, do not worry).
 """
 struct Adjacent{I,E}
-    adjacent::DefaultDict{E,I,I}
+    adjacent::Dict{E,I}
     function Adjacent{I,E}() where {I,E}
-        A = DefaultDict{E,I,I}(I(DefaultAdjacentValue))
+        A = Dict{E,I}()
         adj = new{I,E}(A)
         return adj
     end
-    Adjacent(adj::DefaultDict{E,I,I}) where {I,E} = new{I,E}(adj)
+    Adjacent(adj::Dict{E,I}) where {I,E} = new{I,E}(adj)
 end
 Base.:(==)(adj::Adjacent, adj2::Adjacent) = get_adjacent(adj) == get_adjacent(adj2)
 function Base.show(io::IO, m::MIME"text/plain", adj::Adjacent{I,E}) where {I,E}
@@ -115,7 +115,7 @@ function get_adjacent(adj::Adjacent{I,E}, u, v; check_existence=Val(false), boun
     return get_adjacent(adj, construct_edge(E, u, v); check_existence, boundary_index_ranges)
 end
 
-@inline _get_adjacent(adj::Adjacent{I,E}, uv::E) where {I,E} = get_adjacent(adj)[uv]
+@inline _get_adjacent(adj::Adjacent{I,E}, uv::E) where {I,E} = get(get_adjacent(adj), uv, I(DefaultAdjacentValue))
 @inline function _safe_get_adjacent(adj::Adjacent{I,E}, uv::E, boundary_index_ranges=nothing) where {I,E}
     u = initial(uv)
     v = terminal(uv)

--- a/src/operations/clear_empty_features.jl
+++ b/src/operations/clear_empty_features.jl
@@ -4,10 +4,8 @@
 Clears all empty features from the triangulation `tri`.
 """
 function clear_empty_features!(tri)
-    adj = get_adjacent(tri)
     adj2v = get_adjacent2vertex(tri)
     graph = get_graph(tri)
-    clear_empty_keys!(adj)
     clear_empty_keys!(adj2v)
     clear_empty_points!(graph)
     return nothing

--- a/test/data_structures/adjacent.jl
+++ b/test/data_structures/adjacent.jl
@@ -4,9 +4,9 @@ using DataStructures
 using StaticArrays
 
 global def_adj = DT.DefaultAdjacentValue
-global default_1 = DefaultDict{NTuple{2,Int64},Int64,Int64}(def_adj)
-global default_2 = DefaultDict{NTuple{2,Int32},Int32,Int32}(Int32(def_adj))
-global default_3 = DefaultDict{Vector{Int64},Int64,Int64}(def_adj)
+global default_1 = Dict{NTuple{2,Int64},Int64}()
+global default_2 = Dict{NTuple{2,Int32},Int32}()
+global default_3 = Dict{Vector{Int64},Int64}()
 global adj_1 = DT.Adjacent{Int64,NTuple{2,Int64}}()
 global adj_2 = DT.Adjacent{Int32,NTuple{2,Int32}}()
 global adj_3 = DT.Adjacent{Int64,Vector{Int64}}()
@@ -28,9 +28,9 @@ global dict_2 = Dict(@SVector[1, 2] => 4, @SVector[2, 3] => 10, @SVector[5, 6] =
     @SVector[20, 5] => 72)
 global dict_3 = Dict{NTuple{2,Int32},Int32}((1, 2) => 4, (2, 3) => 10, (5, 6) => 15,
     (20, 5) => 72)
-global ddict_1 = DefaultDict(def_adj, dict_1)
-global ddict_2 = DefaultDict(def_adj, dict_2)
-global ddict_3 = DefaultDict(Int32(def_adj), dict_3)
+global ddict_1 = Dict(dict_1)
+global ddict_2 = Dict(dict_2)
+global ddict_3 = Dict(dict_3)
 global adj_1 = DT.Adjacent(ddict_1)
 global adj_2 = DT.Adjacent(ddict_2)
 global adj_3 = DT.Adjacent(ddict_3)
@@ -78,6 +78,7 @@ global adj_3 = DT.Adjacent(ddict_3)
 
         DT.delete_triangle!(adj, 60, 61, 62)
         @test get_adjacent(adj, 60, 61) == def_adj
+        @inferred get_adjacent(adj, 60, 61)
         @test get_adjacent(adj, 61, 62) == def_adj
         @test get_adjacent(adj, 62, 60) == def_adj
 
@@ -102,18 +103,8 @@ global adj_3 = DT.Adjacent(ddict_3)
     end
 end
 
-@testset "Testing if edges exist and clearing any empty edges" begin
+@testset "Testing if edges exist" begin
     include("../helper_functions.jl")
     tri = triangulate(rand(2, 50))
     @test !DT.edge_exists(get_adjacent(tri, 122, -7; check_existence=false))
-
-    dict = Dict((1, 2) => 4, (2, 3) => 10, (5, 6) => 15, (20, 5) => 72)
-    ddict = DefaultDict(def_adj, dict)
-    adj = DT.Adjacent(ddict)
-    clean_adj = deepcopy(adj)
-    get_adjacent(adj, 107, 108)
-    get_adjacent(adj, 132, 185)
-    @test adj ≠ clean_adj
-    DT.clear_empty_keys!(adj)
-    @test adj == clean_adj
 end

--- a/test/data_structures/triangulation.jl
+++ b/test/data_structures/triangulation.jl
@@ -89,7 +89,7 @@ end
                   tri.adjacent.adjacent[(92, -6)]
             @test DT.get_adjacent(tri, (723, 1356)) ==
                   DT.get_adjacent(tri, (723, 1356); check_existence=Val(true)) ==
-                  tri.adjacent.adjacent[(723, 1356)]
+                  get(tri.adjacent.adjacent, (723, 1356), DT.DefaultAdjacentValue)
             @inferred DT.get_adjacent(tri, (723, 1356))
             @inferred DT.get_adjacent(tri, (723, 1356); check_existence=Val(true))
             DT.add_adjacent!(tri, 101117, 20311, 5)
@@ -472,8 +472,6 @@ end
             @test clean_tri ≠ tri
             DT.delete_adjacent2vertex!(tri, 3, 58, 60)
             DT.delete_neighbour!(tri, 5, 171)
-            @test clean_tri ≠ tri
-            DT.clear_empty_features!(tri)
             @test clean_tri == tri
             _tri = triangulate_rectangle(0.0, 10.0, 0.0, 20.0, 11, 21)
             T = (51, 41, 52)

--- a/test/helper_functions.jl
+++ b/test/helper_functions.jl
@@ -719,7 +719,7 @@ function example_triangulation()
         1 1 0 1 1 0 0
     ]
     DG = DT.Graph(DT.SimpleGraphs.relabel(DT.SimpleGraphs.UndirectedGraph(A), Dict(1:7 .=> [-1, (1:6)...])))
-    adj = DT.Adjacent(DT.DataStructures.DefaultDict(DT.DefaultAdjacentValue,
+    adj = DT.Adjacent(
         Dict(
             (6, 3) => 1, (3, 1) => 6, (1, 6) => 3,
             (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
@@ -730,7 +730,7 @@ function example_triangulation()
             (2, 3) => DT.BoundaryIndex, (3, 6) => DT.BoundaryIndex,
             (6, 4) => DT.BoundaryIndex
         )
-    ))
+    )
     adj2v = DT.Adjacent2Vertex(Dict(
         DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 2), (2, 3), (3, 6), (6, 4)]),
         1 => Set{NTuple{2,Int64}}([(5, 4), (3, 5), (6, 3), (4, 6)]),
@@ -762,7 +762,7 @@ function example_empty_triangulation()
     T = Set{NTuple{3,Int64}}([])
     A = zeros(Int64, 0, 0)
     DG = DT.Graph(DT.SimpleGraphs.UndirectedGraph(A))
-    adj = DT.Adjacent(DT.DataStructures.DefaultDict(DT.DefaultAdjacentValue, Dict{NTuple{2,Int64},Int64}()))
+    adj = DT.Adjacent(Dict{NTuple{2,Int64},Int64}())
     adj2v = DT.Adjacent2Vertex(Dict(DT.BoundaryIndex => Set{NTuple{2,Int64}}()))
     rep = DT.get_empty_representative_points()
     DT.compute_representative_points!(rep, pts, [1, 2, 3, 1])

--- a/test/operations/add_triangle.jl
+++ b/test/operations/add_triangle.jl
@@ -50,7 +50,7 @@ end
       DT.add_triangle!(tri, (u, v, w); update_ghost_edges=true)
       BI = DT.BoundaryIndex
       @test get_triangles(tri) == Set(((u, v, w), (w, v, BI), (v, u, BI), (u, w, BI)))
-      @test get_adjacent(get_adjacent(tri)).d.d == Dict((u, v) => w,
+      @test get_adjacent(get_adjacent(tri)) == Dict((u, v) => w,
             (v, w) => u,
             (w, u) => v,
             (w, v) => BI,
@@ -86,7 +86,7 @@ end
                   (4, 6, 1),
                   (5, 1, 3)
             ])
-            true_adj = DefaultDict(DT.DefaultAdjacentValue,
+            true_adj = 
                   Dict(
                         (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                         (1, 3) => 7, (3, 7) => 1, (7, 1) => 3,
@@ -98,7 +98,6 @@ end
                         (2, 3) => DT.BoundaryIndex, (3, 6) => DT.BoundaryIndex,
                         (6, 4) => DT.BoundaryIndex
                   )
-            )
             true_adj2v = Dict(
                   DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 2), (2, 3), (3, 6), (6, 4)]),
                   1 => Set{NTuple{2,Int64}}([(3, 7), (3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -142,7 +141,7 @@ end
                         (5, 1, 3),
                         (i, j, k)
                   ])
-                  true_adj = DefaultDict(DT.DefaultAdjacentValue,
+                  true_adj = 
                         Dict(
                               (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                               (1, 3) => 7, (3, 7) => 1, (7, 1) => 3,
@@ -155,7 +154,6 @@ end
                               (8, 2) => DT.BoundaryIndex, (2, 3) => DT.BoundaryIndex,
                               (3, 6) => DT.BoundaryIndex, (6, 4) => DT.BoundaryIndex
                         )
-                  )
                   true_adj2v = Dict(
                         DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 8), (8, 2), (2, 3), (3, 6), (6, 4)]),
                         1 => Set{NTuple{2,Int64}}([(3, 7), (3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -204,7 +202,7 @@ end
                         (5, 2, 8),
                         (i, j, k)
                   ])
-                  true_adj = DefaultDict(DT.DefaultAdjacentValue,
+                  true_adj =
                         Dict(
                               (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                               (1, 3) => 7, (3, 7) => 1, (7, 1) => 3,
@@ -218,7 +216,6 @@ end
                               (8, 2) => DT.BoundaryIndex, (2, 6) => DT.BoundaryIndex,
                               (6, 4) => DT.BoundaryIndex
                         )
-                  )
                   true_adj2v = Dict(
                         DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 8), (8, 2), (2, 6), (6, 4)]),
                         1 => Set{NTuple{2,Int64}}([(3, 7), (3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -255,9 +252,9 @@ end
 @testset "Empty triangulation" begin
       tri = example_empty_triangulation()
       true_T = Set{NTuple{3,Int64}}([(1, 2, 3)])
-      true_adj = DefaultDict(DT.DefaultAdjacentValue,
+      true_adj = 
             Dict((1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
-                  (3, 2) => DT.BoundaryIndex, (2, 1) => DT.BoundaryIndex, (1, 3) => DT.BoundaryIndex))
+                  (3, 2) => DT.BoundaryIndex, (2, 1) => DT.BoundaryIndex, (1, 3) => DT.BoundaryIndex)
       true_adj2v = Dict(
             DT.BoundaryIndex => Set{NTuple{2,Int64}}([(3, 2), (2, 1), (1, 3)]),
             1 => Set{NTuple{2,Int64}}([(2, 3)]),
@@ -288,13 +285,13 @@ end
             (2, 1, DT.BoundaryIndex),
             (1, 3, DT.BoundaryIndex),
             (3, 2, DT.BoundaryIndex)])
-      true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+      true_adj = DT.Adjacent(
             Dict(
                   (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
                   (2, 1) => DT.BoundaryIndex, (1, DT.BoundaryIndex) => 2, (DT.BoundaryIndex, 2) => 1,
                   (1, 3) => DT.BoundaryIndex, (3, DT.BoundaryIndex) => 1, (DT.BoundaryIndex, 1) => 3,
                   (3, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 2
-            )))
+            ))
       true_adj2v = DT.Adjacent2Vertex(
             Dict(
                   DT.BoundaryIndex => Set{NTuple{2,Int64}}([(2, 1), (1, 3), (3, 2)]),
@@ -321,7 +318,7 @@ end
             (3, 4, DT.BoundaryIndex),
             (4, 2, DT.BoundaryIndex),
             (3, 2, 4)])
-      true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+      true_adj = DT.Adjacent(
             Dict(
                   (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
                   (2, 1) => DT.BoundaryIndex, (1, DT.BoundaryIndex) => 2, (DT.BoundaryIndex, 2) => 1,
@@ -329,7 +326,7 @@ end
                   (3, 4) => DT.BoundaryIndex, (4, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 4,
                   (4, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 2,
                   (3, 2) => 4, (2, 4) => 3, (4, 3) => 2
-            )))
+            ))
       true_adj2v = DT.Adjacent2Vertex(
             Dict(
                   DT.BoundaryIndex => Set{NTuple{2,Int64}}([(2, 1), (1, 3), (3, 4), (4, 2)]),
@@ -366,7 +363,7 @@ end
             (4, 6, DT.BoundaryIndex),
             (6, 2, DT.BoundaryIndex)
       ])
-      true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+      true_adj = DT.Adjacent(
             Dict(
                   (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
                   (3, 2) => 4, (2, 4) => 3, (4, 3) => 2,
@@ -378,7 +375,7 @@ end
                   (5, 4) => DT.BoundaryIndex, (4, DT.BoundaryIndex) => 5, (DT.BoundaryIndex, 5) => 4,
                   (4, 6) => DT.BoundaryIndex, (6, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 6,
                   (6, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 6, (DT.BoundaryIndex, 6) => 2
-            )))
+            ))
       true_adj2v = DT.Adjacent2Vertex(
             Dict(
                   DT.BoundaryIndex => Set{NTuple{2,Int64}}([(1, 3), (3, 5), (5, 4), (4, 6), (6, 2), (2, 1)]),
@@ -415,7 +412,7 @@ end
             (5, 6, DT.BoundaryIndex),
             (6, 2, DT.BoundaryIndex)
       ])
-      true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+      true_adj = DT.Adjacent(
             Dict(
                   (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
                   (3, 2) => 4, (2, 4) => 3, (4, 3) => 2,
@@ -427,7 +424,7 @@ end
                   (3, 5) => DT.BoundaryIndex, (5, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 5,
                   (5, 6) => DT.BoundaryIndex, (6, DT.BoundaryIndex) => 5, (DT.BoundaryIndex, 5) => 6,
                   (6, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 6, (DT.BoundaryIndex, 6) => 2
-            )))
+            ))
       true_adj2v = DT.Adjacent2Vertex(
             Dict(
                   DT.BoundaryIndex => Set{NTuple{2,Int64}}([(1, 3), (3, 5), (5, 6), (6, 2), (2, 1)]),
@@ -510,8 +507,6 @@ end
             (3, 2, DT.BoundaryIndex)
       ])
       true_adj = DT.Adjacent(
-            DefaultDict(
-                  DT.DefaultAdjacentValue,
                   Dict(
                         (1, 6) => 8, (6, 8) => 1, (8, 1) => 6,
                         (1, 8) => 9, (8, 9) => 1, (9, 1) => 8,
@@ -534,7 +529,6 @@ end
                         (4, 3) => DT.BoundaryIndex, (3, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 3,
                         (3, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 2
                   )
-            )
       )
       true_adj2v = DT.Adjacent2Vertex{Int64,Set{NTuple{2,Int64}},NTuple{2,Int64}}()
       for (ij, k) in true_adj

--- a/test/operations/delete_triangle.jl
+++ b/test/operations/delete_triangle.jl
@@ -65,22 +65,19 @@ end
             (5, 2, 8),
             (6, 2, 3)
         ])
-        true_adj = DefaultDict(DT.DefaultAdjacentValue,
+        true_adj =
             Dict(
                 (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                 (4, 1) => 5, (1, 5) => 4, (5, 4) => 1,
                 (6, 3) => 1, (3, 1) => 6, (1, 6) => 3,
                 (4, 6) => 1, (6, 1) => 4, (1, 4) => 6,
                 (5, 1) => 3, (3, 5) => 1,
-                (1, 7) => DT.DefaultAdjacentValue,
-                (7, 3) => DT.DefaultAdjacentValue,
                 (5, 2) => 8, (2, 8) => 5, (8, 5) => 2,
                 (2, 3) => 6, (3, 6) => 2, (6, 2) => 3,
                 (4, 5) => DT.BoundaryIndex, (5, 8) => DT.BoundaryIndex,
                 (8, 2) => DT.BoundaryIndex, (2, 6) => DT.BoundaryIndex,
                 (6, 4) => DT.BoundaryIndex
             )
-        )
         true_adj2v = Dict(
             DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 8), (8, 2), (2, 6), (6, 4)]),
             1 => Set{NTuple{2,Int64}}([(3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -124,7 +121,7 @@ end
                 (5, 1, 3),
                 (6, 2, 3)
             ])
-            true_adj = DefaultDict(DT.DefaultAdjacentValue,
+            true_adj = 
                 Dict(
                     (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                     (4, 1) => 5, (1, 5) => 4, (5, 4) => 1,
@@ -136,7 +133,6 @@ end
                     (5, 2) => DT.BoundaryIndex, (2, 6) => DT.BoundaryIndex,
                     (6, 4) => DT.BoundaryIndex
                 )
-            )
             true_adj2v = Dict(
                 DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 2), (2, 6), (6, 4)]),
                 1 => Set{NTuple{2,Int64}}([(3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -179,7 +175,7 @@ end
                 (4, 6, 1),
                 (5, 1, 3),
             ])
-            true_adj = DefaultDict(DT.DefaultAdjacentValue,
+            true_adj =
                 Dict(
                     (3, 2) => 5, (2, 5) => 3, (5, 3) => 2,
                     (4, 1) => 5, (1, 5) => 4, (5, 4) => 1,
@@ -191,7 +187,6 @@ end
                     (6, 4) => DT.BoundaryIndex,
                     (2, 3) => DT.BoundaryIndex, (3, 6) => DT.BoundaryIndex,
                 )
-            )
             true_adj2v = Dict(
                 DT.BoundaryIndex => Set{NTuple{2,Int64}}([(4, 5), (5, 2), (2, 3), (3, 6), (6, 4)]),
                 1 => Set{NTuple{2,Int64}}([(3, 5), (6, 3), (5, 4), (4, 6)]),
@@ -269,7 +264,7 @@ end
         (4, 6, DT.BoundaryIndex),
         (6, 2, DT.BoundaryIndex)
     ])
-    true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+    true_adj = DT.Adjacent(
         Dict(
             (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
             (3, 2) => 4, (2, 4) => 3, (4, 3) => 2,
@@ -281,7 +276,7 @@ end
             (5, 4) => DT.BoundaryIndex, (4, DT.BoundaryIndex) => 5, (DT.BoundaryIndex, 5) => 4,
             (4, 6) => DT.BoundaryIndex, (6, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 6,
             (6, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 6, (DT.BoundaryIndex, 6) => 2
-        )))
+        ))
     true_adj2v = DT.Adjacent2Vertex(
         Dict(
             DT.BoundaryIndex => Set{NTuple{2,Int64}}([(1, 3), (3, 5), (5, 4), (4, 6), (6, 2), (2, 1)]),
@@ -313,7 +308,7 @@ end
         (3, 4, DT.BoundaryIndex),
         (4, 2, DT.BoundaryIndex),
         (3, 2, 4)])
-    true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+    true_adj = DT.Adjacent(
         Dict(
             (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
             (2, 1) => DT.BoundaryIndex, (1, DT.BoundaryIndex) => 2, (DT.BoundaryIndex, 2) => 1,
@@ -321,7 +316,7 @@ end
             (3, 4) => DT.BoundaryIndex, (4, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 4,
             (4, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 2,
             (3, 2) => 4, (2, 4) => 3, (4, 3) => 2
-        )))
+        ))
     true_adj2v = DT.Adjacent2Vertex(
         Dict(
             DT.BoundaryIndex => Set{NTuple{2,Int64}}([(2, 1), (1, 3), (3, 4), (4, 2)]),
@@ -347,13 +342,13 @@ end
         (2, 1, DT.BoundaryIndex),
         (1, 3, DT.BoundaryIndex),
         (3, 2, DT.BoundaryIndex)])
-    true_adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+    true_adj = DT.Adjacent(
         Dict(
             (1, 2) => 3, (2, 3) => 1, (3, 1) => 2,
             (2, 1) => DT.BoundaryIndex, (1, DT.BoundaryIndex) => 2, (DT.BoundaryIndex, 2) => 1,
             (1, 3) => DT.BoundaryIndex, (3, DT.BoundaryIndex) => 1, (DT.BoundaryIndex, 1) => 3,
             (3, 2) => DT.BoundaryIndex, (2, DT.BoundaryIndex) => 3, (DT.BoundaryIndex, 3) => 2
-        )))
+        ))
     true_adj2v = DT.Adjacent2Vertex(
         Dict(
             DT.BoundaryIndex => Set{NTuple{2,Int64}}([(2, 1), (1, 3), (3, 2)]),
@@ -435,7 +430,6 @@ end
         (6, 1, DT.BoundaryIndex)
     ])
     true_adj = DT.Adjacent(
-        DefaultDict(DT.DefaultAdjacentValue,
             Dict(
                 (1, 6) => 8, (6, 8) => 1, (8, 1) => 6,
                 (6, 7) => 8, (7, 8) => 6, (8, 6) => 7,
@@ -451,7 +445,7 @@ end
                 (7, 4) => DT.BoundaryIndex, (4, DT.BoundaryIndex) => 7, (DT.BoundaryIndex, 7) => 4,
                 (4, 6) => DT.BoundaryIndex, (6, DT.BoundaryIndex) => 4, (DT.BoundaryIndex, 4) => 6,
                 (6, 1) => DT.BoundaryIndex, (1, DT.BoundaryIndex) => 6, (DT.BoundaryIndex, 6) => 1
-            ))
+            )
     )
     true_adj2v = DT.Adjacent2Vertex{Int64,Set{NTuple{2,Int64}},NTuple{2,Int64}}()
     for (ij, k) in true_adj

--- a/test/predicates/boundaries_and_ghosts.jl
+++ b/test/predicates/boundaries_and_ghosts.jl
@@ -33,14 +33,14 @@ boundary_nodes = get_boundary_nodes(tri2)
 end
 
 @testset "is_boundary_edge" begin
-    adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+    adj = DT.Adjacent(
         Dict((1, 2) => 5,
             (2, 7) => 1,
             (5, 3) => BI,
             (3, 5) => 7,
             (5, 7) => BI - 1,
             (7, 5) => 13,
-            (13, 3) => BI - 2)))
+            (13, 3) => BI - 2))
     results = [false, false, true, false, true, false, true, false, false]
     edges = [(1, 2), (2, 7), (5, 3), (3, 5), (5, 7), (7, 5), (13, 3), (23, 5), (36, 3)]
     for (ij, result) in zip(edges, results)

--- a/test/triangulation/bowyer_watson.jl
+++ b/test/triangulation/bowyer_watson.jl
@@ -48,7 +48,7 @@ end
     u, v, w = first(S)
     BI = DT.BoundaryIndex
     @test get_triangles(_tri) == Set(((u, v, w), (w, v, BI), (v, u, BI), (u, w, BI)))
-    @test get_adjacent(get_adjacent(_tri)).d.d == Dict((u, v) => w,
+    @test get_adjacent(get_adjacent(_tri)) == Dict((u, v) => w,
         (v, w) => u,
         (w, u) => v,
         (w, v) => BI,
@@ -72,7 +72,7 @@ end
     u, v, w = first(S)
     BI = DT.BoundaryIndex
     @test get_triangles(_tri) == Set(((u, v, w), (w, v, BI), (v, u, BI), (u, w, BI)))
-    @test get_adjacent(get_adjacent(_tri)).d.d == Dict((u, v) => w,
+    @test get_adjacent(get_adjacent(_tri)) == Dict((u, v) => w,
         (v, w) => u,
         (w, u) => v,
         (w, v) => BI,
@@ -164,7 +164,7 @@ end
             (8, 9, 3),
             (9, 7, 3),
             (3, 7, 4)))
-        adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+        adj = DT.Adjacent(
             Dict(@_adj(2, 9, 8)...,
                 @_adj(2, 8, 6)...,
                 @_adj(2, 6, 1)...,
@@ -182,8 +182,8 @@ end
                 @_adj(4, 7, DT.BoundaryIndex)...,
                 @_adj(7, 9, DT.BoundaryIndex)...,
                 @_adj(9, 2, DT.BoundaryIndex)...,
-                @_adj(2, 1, DT.BoundaryIndex)...)))
-        adj2 = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+                @_adj(2, 1, DT.BoundaryIndex)...))
+        adj2 = DT.Adjacent(
             Dict(@_adj(2, 9, 8)...,
                 @_adj(2, 8, 6)...,
                 @_adj(2, 6, 1)...,
@@ -201,7 +201,7 @@ end
                 (4, 7) => DT.BoundaryIndex,
                 (7, 9) => DT.BoundaryIndex,
                 (9, 2) => DT.BoundaryIndex,
-                (2, 1) => DT.BoundaryIndex)))
+                (2, 1) => DT.BoundaryIndex))
         adj2v = DT.Adjacent2Vertex(Dict(DT.BoundaryIndex => Set{NTuple{2,Int64}}(((1, 5),
                 (5, 4),
                 (4, 7),

--- a/test/triangulation/convex_triangulation.jl
+++ b/test/triangulation/convex_triangulation.jl
@@ -70,7 +70,6 @@ end
         @test tri_ch.representative_point_list[1].x ≈ _pt[1].x rtol = 1e-1
         @test tri_ch.representative_point_list[1].y ≈ _pt[1].y rtol = 1e-1
         @test tri_ch.representative_point_list[1].n ≈ _pt[1].n
-        @test any(!DT.edge_exists, values(get_adjacent(get_adjacent(tri_ch))))
         DT.convex_triangulation_post_processing!(tri_ch, S[begin:end-1], false, false, false, true)
         @test all(DT.edge_exists, values(get_adjacent(get_adjacent(tri_ch))))
         DT.convex_triangulation_post_processing!(tri_ch, S[begin:end-1], true, false, false, false)

--- a/test/triangulation/gmsh.jl
+++ b/test/triangulation/gmsh.jl
@@ -1126,6 +1126,7 @@ if !(get(ENV, "CI", "false") == "true")
             @test tri.points == nodes
             @test tri.triangles == Set{NTuple{3,Int64}}((T[1], T[2], T[3]) for T in eachcol(elements))
             adj = tri.adjacent.adjacent
+            adj = DefaultDict(DT.DefaultAdjacentValue, adj)
             for T in tri.triangles
                 i, j, k = T
                 @test adj[(i, j)] == k
@@ -1197,19 +1198,19 @@ if !(get(ENV, "CI", "false") == "true")
                     @test T ∈ elset
                 elseif i < DT.FirstPointIndex
                     @test j ∈ bn && k ∈ bn
-                    @test tri.adjacent.adjacent[(j, k)] == i
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(j, k)] == i
                     @test j ∈ tri.graph.graph[DT.BoundaryIndex] && k ∈ tri.graph.graph[DT.BoundaryIndex]
                     @test (j, k) ∈ tri.adjacent2vertex.adjacent2vertex[DT.BoundaryIndex]
                     ng += 1
                 elseif j < DT.FirstPointIndex
                     @test i ∈ bn && k ∈ bn
-                    @test tri.adjacent.adjacent[(k, i)] == j
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(k, i)] == j
                     @test i ∈ tri.graph.graph[DT.BoundaryIndex] && k ∈ tri.graph.graph[DT.BoundaryIndex]
                     @test (k, i) ∈ tri.adjacent2vertex.adjacent2vertex[DT.BoundaryIndex]
                     ng += 1
                 elseif k < DT.FirstPointIndex
                     @test i ∈ bn && j ∈ bn
-                    @test tri.adjacent.adjacent[(i, j)] == k
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(i, j)] == k
                     @test i ∈ tri.graph.graph[DT.BoundaryIndex] && j ∈ tri.graph.graph[DT.BoundaryIndex]
                     @test (i, j) ∈ tri.adjacent2vertex.adjacent2vertex[DT.BoundaryIndex]
                     ng += 1
@@ -1217,6 +1218,7 @@ if !(get(ENV, "CI", "false") == "true")
             end
             @test ng == DT.num_boundary_edges(bn)
             adj = tri.adjacent.adjacent
+            adj = DefaultDict(DT.DefaultAdjacentValue, adj)
             for T in tri.triangles
                 i, j, k = T
                 @test adj[(i, j)] == k
@@ -1287,6 +1289,7 @@ if !(get(ENV, "CI", "false") == "true")
             @test tri.boundary_map == OrderedDict(-(1:4) .=> 1:4)
             @test collect(Base.keys(tri.boundary_map)) == [-1, -2, -3, -4]
             adj = tri.adjacent.adjacent
+            adj = DefaultDict(DT.DefaultAdjacentValue, adj)
             for T in tri.triangles
                 i, j, k = T
                 @test adj[(i, j)] == k
@@ -1365,21 +1368,21 @@ if !(get(ENV, "CI", "false") == "true")
                 elseif i < DT.FirstPointIndex
                     n = tri.boundary_map[i]
                     @test j ∈ bn[n] && k ∈ bn[n]
-                    @test tri.adjacent.adjacent[(j, k)] == i
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(j, k)] == i
                     @test j ∈ tri.graph.graph[i] && k ∈ tri.graph.graph[i]
                     @test (j, k) ∈ tri.adjacent2vertex.adjacent2vertex[i]
                     ng += 1
                 elseif j < DT.FirstPointIndex
                     n = tri.boundary_map[j]
                     @test k ∈ bn[n] && i ∈ bn[n]
-                    @test tri.adjacent.adjacent[(k, i)] == j
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(k, i)] == j
                     @test k ∈ tri.graph.graph[j] && i ∈ tri.graph.graph[j]
                     @test (k, i) ∈ tri.adjacent2vertex.adjacent2vertex[j]
                     ng += 1
                 elseif k < DT.FirstPointIndex
                     n = tri.boundary_map[k]
                     @test i ∈ bn[n] && j ∈ bn[n]
-                    @test tri.adjacent.adjacent[(i, j)] == k
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(i, j)] == k
                     @test i ∈ tri.graph.graph[k] && j ∈ tri.graph.graph[k]
                     @test (i, j) ∈ tri.adjacent2vertex.adjacent2vertex[k]
                     ng += 1
@@ -1389,6 +1392,7 @@ if !(get(ENV, "CI", "false") == "true")
             @test tri.boundary_map == OrderedDict(-(1:4) .=> 1:4)
             @test collect(Base.keys(tri.boundary_map)) == [-1, -2, -3, -4]
             adj = tri.adjacent.adjacent
+            adj = DefaultDict(DT.DefaultAdjacentValue, adj)
             for T in tri.triangles
                 i, j, k = T
                 @test adj[(i, j)] == k
@@ -1477,21 +1481,21 @@ if !(get(ENV, "CI", "false") == "true")
                 elseif i < DT.FirstPointIndex
                     m, n = tri.boundary_map[i]
                     @test j ∈ bn[m][n] && k ∈ bn[m][n]
-                    @test tri.adjacent.adjacent[(j, k)] == i
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(j, k)] == i
                     @test j ∈ tri.graph.graph[i] && k ∈ tri.graph.graph[i]
                     @test (j, k) ∈ tri.adjacent2vertex.adjacent2vertex[i]
                     ng += 1
                 elseif j < DT.FirstPointIndex
                     m, n = tri.boundary_map[j]
                     @test k ∈ bn[m][n] && i ∈ bn[m][n]
-                    @test tri.adjacent.adjacent[(k, i)] == j
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(k, i)] == j
                     @test k ∈ tri.graph.graph[j] && i ∈ tri.graph.graph[j]
                     @test (k, i) ∈ tri.adjacent2vertex.adjacent2vertex[j]
                     ng += 1
                 elseif k < DT.FirstPointIndex
                     m, n = tri.boundary_map[k]
                     @test i ∈ bn[m][n] && j ∈ bn[m][n]
-                    @test tri.adjacent.adjacent[(i, j)] == k
+                    @test DefaultDict(DT.DefaultAdjacentValue, tri.adjacent.adjacent)[(i, j)] == k
                     @test i ∈ tri.graph.graph[k] && j ∈ tri.graph.graph[k]
                     @test (i, j) ∈ tri.adjacent2vertex.adjacent2vertex[k]
                     ng += 1
@@ -1506,6 +1510,7 @@ if !(get(ENV, "CI", "false") == "true")
                 -11 => (5, 1))
             @test collect(Base.keys(tri.boundary_map)) == [-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11]
             adj = tri.adjacent.adjacent
+            adj = DefaultDict(DT.DefaultAdjacentValue, adj)
             for T in tri.triangles
                 i, j, k = T
                 @test adj[(i, j)] == k

--- a/test/triangulation/triangulate.jl
+++ b/test/triangulation/triangulate.jl
@@ -62,7 +62,7 @@ end
             (8, 9, 3),
             (9, 7, 3),
             (3, 7, 4)))
-        adj = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+        adj = DT.Adjacent(
             Dict(@_adj(2, 9, 8)...,
                 @_adj(2, 8, 6)...,
                 @_adj(2, 6, 1)...,
@@ -80,8 +80,8 @@ end
                 @_adj(4, 7, DT.BoundaryIndex)...,
                 @_adj(7, 9, DT.BoundaryIndex)...,
                 @_adj(9, 2, DT.BoundaryIndex)...,
-                @_adj(2, 1, DT.BoundaryIndex)...)))
-        adj2 = DT.Adjacent(DefaultDict(DT.DefaultAdjacentValue,
+                @_adj(2, 1, DT.BoundaryIndex)...))
+        adj2 = DT.Adjacent(
             Dict(@_adj(2, 9, 8)...,
                 @_adj(2, 8, 6)...,
                 @_adj(2, 6, 1)...,
@@ -99,7 +99,7 @@ end
                 (4, 7) => DT.BoundaryIndex,
                 (7, 9) => DT.BoundaryIndex,
                 (9, 2) => DT.BoundaryIndex,
-                (2, 1) => DT.BoundaryIndex)))
+                (2, 1) => DT.BoundaryIndex))
         adj2v = DT.Adjacent2Vertex(Dict(DT.BoundaryIndex => Set{NTuple{2,Int64}}(((1, 5),
                 (5, 4),
                 (4, 7),


### PR DESCRIPTION
It turns out that DefaultDict can cause some annoying concurrency issues. `DefaultDict` turns out to be annoying anyway, shouldn't have to force users to think so much about DefaultAdjacentValue cropping up.