### PR TITLE
Fix remaining O(n) has_ghost_vertices scan (unconstrained triangulate still quadratic on isbnd/hasghst)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## 1.6.6
 
 - The `Triangulation` struct now stores a `has_ghosts::Bool` field and a `boundary_vertex_to_ghost` map for efficient lookup. See [#240](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/240).
+- `has_ghost_vertices(tri)` no longer scans every vertex of the graph. The scan made each query O(n), and point location hit it on every insertion, so unconstrained `triangulate` was quadratic in the number of points (591 s for 250,000 points, now 14 s). See [#236](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/issues/236) and [#247](https://github.com/JuliaGeometry/DelaunayTriangulation.jl/pull/247).
 
 ## 1.6.5
 

--- a/src/data_structures/triangulation/methods/graph.jl
+++ b/src/data_structures/triangulation/methods/graph.jl
@@ -100,7 +100,13 @@ num_vertices(tri::Triangulation) = num_vertices(get_graph(tri))
 
 Returns `true` if `tri` has ghost vertices, and `false` otherwise.
 """
-has_ghost_vertices(tri::Triangulation) = has_ghost_vertices(get_graph(tri))
+function has_ghost_vertices(tri::Triangulation)
+    # Check the registered ghost vertices with O(1) graph-membership lookups instead of
+    # scanning every vertex of the graph. The scan makes each query O(n), and since point
+    # location queries this (via is_boundary_node and each_ghost_vertex) on every insertion,
+    # it makes triangulate quadratic in the number of points. See #236.
+    return any(g -> has_vertex(tri, g), all_ghost_vertices(tri))
+end
 
 """
     num_ghost_vertices(tri::Triangulation) -> Integer

--- a/test/data_structures/triangulation.jl
+++ b/test/data_structures/triangulation.jl
@@ -957,10 +957,28 @@ end
     @test DT.has_vertex(tri, 1)
     @test !DT.has_vertex(tri, 57)
     @test DT.has_ghost_vertices(tri)
+    @test DT.has_ghost_vertices(tri) == DT.has_ghost_vertices(DT.get_graph(tri)) # agrees with the graph-level scan
     @test DT.has_vertex(tri, -1)
     DT.delete_ghost_vertices_from_graph!(tri)
     @test !DT.has_vertex(tri, -1)
     @test !DT.has_ghost_vertices(tri)
+    @test DT.has_ghost_vertices(tri) == DT.has_ghost_vertices(DT.get_graph(tri)) # agrees with the graph-level scan
+
+    # multiple ghost vertices (constrained triangulation with an interior hole)
+    curve_1 = [[1, 2, 3, 4, 5, 6, 7, 1]]
+    points_1 = [
+        (0.0, 0.0), (4.0, 0.0), (8.0, 0.0), (8.0, 4.0),
+        (8.0, 8.0), (4.0, 8.0), (0.0, 8.0),
+    ]
+    curve_2 = [[8, 9, 10, 11, 8]]
+    points_2 = [(6.0, 2.0), (6.0, 3.0), (7.0, 3.0), (7.0, 2.0)]
+    points = [points_1..., points_2...]
+    tri2 = triangulate(points; boundary_nodes = [curve_1, curve_2], delete_ghosts = false)
+    @test DT.has_ghost_vertices(tri2)
+    @test DT.has_ghost_vertices(tri2) == DT.has_ghost_vertices(DT.get_graph(tri2))
+    DT.delete_ghost_vertices_from_graph!(tri2)
+    @test !DT.has_ghost_vertices(tri2)
+    @test DT.has_ghost_vertices(tri2) == DT.has_ghost_vertices(DT.get_graph(tri2))
 end
 
 @testset "Issue #70" begin


### PR DESCRIPTION
Supplements #240 (thanks for that branch!) — one more method needs the same treatment, otherwise **unconstrained** `triangulate` remains quadratic. Together with #240's changes this makes `triangulate` near-linear end to end. Refs #236.

## Why #240 alone doesn't cover the unconstrained path

`boundary_vertex_to_ghost` is only populated by `add_boundary_information!` during **postprocessing**, so during the entire incremental phase of an unconstrained triangulation the map is empty and `is_boundary_node` takes its fallback:

- `_find_triangle` calls `is_boundary_node(tri, k)` on every point-location query (`jump_and_march.jl:1137`);
- the fallback iterates `each_ghost_vertex(tri)`, and **every** `iterate(::EachGhostVertex)` re-checks `has_ghost_vertices(itr.tri)` (`methods/iterators.jl:113`);
- `has_ghost_vertices(tri)` forwarded to the `Graph`-level `any(is_ghost_vertex, get_vertices(G))` — an O(n) scan over the full vertex `Set` (`graph.jl:294`).

O(n) per insertion × n insertions ⇒ O(n²).

## Fix

Replace the forward with O(1) graph-membership lookups over the registered ghost vertices:

```julia
has_ghost_vertices(tri::Triangulation) = any(g -> has_vertex(tri, g), all_ghost_vertices(tri))
```

Semantics unchanged — the result still reflects whether the *graph* currently contains ghost vertices (e.g. it flips to `false` after `delete_ghost_vertices_from_graph!`), and this also fixes the other callers (`num_ghost_vertices`, `num_solid_vertices`, `each_ghost_vertex`). The `Graph`-level method is untouched.

## Reproduction / benchmarks

```julia
using DelaunayTriangulation, Random
Random.seed!(1)
for n in (20_000, 40_000, 80_000)
    pts = [(rand() - 0.5, rand() - 0.5) for _ in 1:n]
    t = @elapsed triangulate(pts)
    println("n = $n: $t s")
end
```

Julia 1.12.2, Windows 11 (times in seconds; uniform random points, one warm-up call first):

| n | v1.6.6 release | `isbnd/hasghst` | `isbnd/hasghst` + this PR |
|--:|--:|--:|--:|
| 20,000 | 3.75 | 2.77 | **0.36** |
| 40,000 | 24.1 | 19.1 | — |
| 80,000 | 50.7 | 89.3 | **2.45** |
| 250,000 | ~590 | (not run) | **14.4** |

Weighted triangulations (my use case — power diagrams for semi-discrete optimal transport over 250k sites) behave identically: 250k went from ~591 s to 14.6 s.

Profiling v1.6.6 at n = 40,000 attributes ~89% of samples to `has_ghost_vertices` → `any` → `Set` iteration, reached through both `is_boundary_node` (via the `each_ghost_vertex` iterate) and `has_ghost_triangles` → `num_ghost_vertices`; #240 already fixes the latter chain with the `has_ghosts` flag, and this PR fixes the former.

## Tests

Extended the existing `has_vertex and has_ghost_vertices` testset:
- asserts the new method agrees with the `Graph`-level scan in every state (before/after `delete_ghost_vertices_from_graph!`);
- adds a multiply-connected domain (interior hole ⇒ multiple ghost vertices) exercised through the same states.

NEWS entry added in a follow-up commit with this PR's number. Happy to adjust anything — including folding this directly into #240 if you'd rather cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)